### PR TITLE
Sort OIDs by numeric value

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*     text eol=lf
+*.c   text eol=crlf
+*.cfg text eol=crlf

--- a/dumpasn1.cfg
+++ b/dumpasn1.cfg
@@ -1288,6 +1288,12 @@ OID = 0 4 0 2042 1 7
 Comment = ETSI TS 102 042 Certificate Policies
 Description = etsiOVCertificatePolicy
 
+# ETSI EN 319 422 Time-stamping protocol and time-stamp token profiles
+
+OID = 0 4 0 19422 1 1
+Comment = ETSI EN 319 422 Timestamping Profiles
+Description = etsiEuQCompliance
+
 # EU Qualified Certificates
 
 OID = 0 4 0 194112 1 0
@@ -1325,12 +1331,6 @@ Description = qcsSemanticsIdeIDASNatural
 OID = 0 4 0 194121 1 4
 Comment = EU Qualified Certificate Identifier
 Description = qcsSemanticsIdeIDASLegal
-
-# ETSI EN 319 422 Time-stamping protocol and time-stamp token profiles
-
-OID = 0 4 0 19422 1 1
-Comment = ETSI EN 319 422 Timestamping Profiles
-Description = etsiEuQCompliance
 
 # RFC 1274 (X.500 attribute collection from the UK, thus the weird OID).
 
@@ -1668,6 +1668,22 @@ OID = 1 2 36 75878867 1 100 1 1
 Comment = Certificates Australia CA
 Description = certificatesAustraliaPolicy
 
+# EV certificate policies.  There's no official record of what all the EV
+# policy OIDs are, it seems to be defined as "whatever the browsers will
+# accept as EV".  This is taken from
+# https://en.wikipedia.org/wiki/Extended_Validation_Certificate, there's also
+# a list in Chromium, the ev_root_ca_metadata list, but this contains
+# errors (e.g. the value "1.3.6.1.4.1.6449.1.2.1.5.1" [sic] is recorded as
+# being for both AddTrust and Comodo).
+#
+# The OIDs are collected here in owner-name alphabetical order rather than
+# scattering them throughout this list in OID order to make it easier to
+# track what's already present.
+
+OID = 1 2 40 0 17 1 22
+Comment = A-Trust CA Root
+Description = A-Trust EV policy
+
 # Belarus
 
 OID = 1 2 112 0 2 0 34 101 45 2 1
@@ -1877,6 +1893,10 @@ Description = mitsubishiSecurityAlgorithm
 OID = 1 2 392 200011 61 1 1 1 1
 Comment = Mitsubishi security algorithm
 Description = misty1-cbc
+
+OID = 1 2 392 200091 100 721 1
+Comment = Security Communication RootCA1
+Description = Security Communication (SECOM) EV policy
 
 # Korean Information Security Agency
 
@@ -2192,6 +2212,30 @@ Comment = GOST R 34.10-94 + GOST R 34.11-94 signature. Obsoleted by GOST R 34.10
 Description = gost94Signature
 Warning
 
+OID = 1 2 643 2 2 9
+Comment = GOST R 34.11-94 digest
+Description = gostDigest
+
+OID = 1 2 643 2 2 10
+Comment = HMAC with GOST R 34.11-94
+Description = hmacGost
+
+OID = 1 2 643 2 2 13 0
+Comment = Wrap key using GOST 28147-89 key
+Description = gostWrap
+
+OID = 1 2 643 2 2 13 1
+Comment = Wrap key using diversified GOST 28147-89 key
+Description = cryptoProWrap
+
+OID = 1 2 643 2 2 14 0
+Comment = Do not mesh state of GOST 28147-89 cipher
+Description = nullMeshing
+
+OID = 1 2 643 2 2 14 1
+Comment = CryptoPro meshing of state of GOST 28147-89 cipher
+Description = cryptoProMeshing
+
 OID = 1 2 643 2 2 19
 Comment = GOST R 34.10-2001 (ECC) public key
 Description = gostPublicKey
@@ -2204,6 +2248,26 @@ Warning
 OID = 1 2 643 2 2 21
 Comment = GOST 28147-89 (symmetric key block cipher)
 Description = gostCipher
+
+OID = 1 2 643 2 2 30 0
+Comment = Test params for GOST R 34.11-94
+Description = testDigestParams
+
+OID = 1 2 643 2 2 30 1
+Comment = CryptoPro digest params A (default, variant 'Verba-O') for GOST R 34.11-94
+Description = cryptoProDigestA
+
+OID = 1 2 643 2 2 30 2
+Comment = CryptoPro digest params B (variant 1) for GOST R 34.11-94
+Description = cryptoProDigestB
+
+OID = 1 2 643 2 2 30 3
+Comment = CryptoPro digest params C (variant 2) for GOST R 34.11-94
+Description = cryptoProDigestC
+
+OID = 1 2 643 2 2 30 4
+Comment = CryptoPro digest params D (variant 3) for GOST R 34.11-94
+Description = cryptoProDigestD
 
 OID = 1 2 643 2 2 31 0
 Comment = Test params for GOST 28147-89
@@ -2261,34 +2325,6 @@ OID = 1 2 643 2 2 31 17
 Comment = TC26 params 6 for GOST 28147-89
 Description = tc26CipherF
 
-OID = 1 2 643 7 1 2 5 1 1
-Comment = TC26 params Z for GOST 28147-89
-Description = tc26CipherZ
-
-OID = 1 2 643 2 2 9
-Comment = GOST R 34.11-94 digest
-Description = gostDigest
-
-OID = 1 2 643 2 2 30 0
-Comment = Test params for GOST R 34.11-94
-Description = testDigestParams
-
-OID = 1 2 643 2 2 30 1
-Comment = CryptoPro digest params A (default, variant 'Verba-O') for GOST R 34.11-94
-Description = cryptoProDigestA
-
-OID = 1 2 643 2 2 30 2
-Comment = CryptoPro digest params B (variant 1) for GOST R 34.11-94
-Description = cryptoProDigestB
-
-OID = 1 2 643 2 2 30 3
-Comment = CryptoPro digest params C (variant 2) for GOST R 34.11-94
-Description = cryptoProDigestC
-
-OID = 1 2 643 2 2 30 4
-Comment = CryptoPro digest params D (variant 3) for GOST R 34.11-94
-Description = cryptoProDigestD
-
 OID = 1 2 643 2 2 32 2
 Comment = CryptoPro sign params A (default, variant 'Verba-O') for GOST R 34.10-94
 Description = cryptoPro94SignA
@@ -2341,42 +2377,6 @@ OID = 1 2 643 2 2 36 1
 Comment = CryptoPro ell.curve XB for GOST R 34.10-2001
 Description = cryptoProSignXB
 
-OID = 1 2 643 7 1 2 1 1 1
-Comment = CryptoPro ell.curve A for GOST R 34.10-2012 256 bit
-Description = cryptoPro2012Sign256A
-
-OID = 1 2 643 7 1 2 1 2 1
-Comment = CryptoPro ell.curve A (default) for GOST R 34.10-2012 512 bit
-Description = cryptoPro2012Sign512A
-
-OID = 1 2 643 7 1 2 1 2 2
-Comment = CryptoPro ell.curve B for GOST R 34.10-2012 512 bit
-Description = cryptoPro2012Sign512B
-
-OID = 1 2 643 7 1 2 1 2 3
-Comment = CryptoPro ell.curve C for GOST R 34.10-2012 512 bit
-Description = cryptoPro2012Sign512C
-
-OID = 1 2 643 2 2 14 0
-Comment = Do not mesh state of GOST 28147-89 cipher
-Description = nullMeshing
-
-OID = 1 2 643 2 2 14 1
-Comment = CryptoPro meshing of state of GOST 28147-89 cipher
-Description = cryptoProMeshing
-
-OID = 1 2 643 2 2 10
-Comment = HMAC with GOST R 34.11-94
-Description = hmacGost
-
-OID = 1 2 643 2 2 13 0
-Comment = Wrap key using GOST 28147-89 key
-Description = gostWrap
-
-OID = 1 2 643 2 2 13 1
-Comment = Wrap key using diversified GOST 28147-89 key
-Description = cryptoProWrap
-
 OID = 1 2 643 2 2 96
 Comment = Wrap key using ECC DH on GOST R 34.10-2001 keys (VKO)
 Description = cryptoProECDHWrap
@@ -2412,6 +2412,26 @@ Description = cryptoProECDH256
 OID = 1 2 643 7 1 1 6 2
 Comment = CryptoPro ECC DH algorithm for GOST R 34.10-2012 512 bit key
 Description = cryptoProECDH512
+
+OID = 1 2 643 7 1 2 1 1 1
+Comment = CryptoPro ell.curve A for GOST R 34.10-2012 256 bit
+Description = cryptoPro2012Sign256A
+
+OID = 1 2 643 7 1 2 1 2 1
+Comment = CryptoPro ell.curve A (default) for GOST R 34.10-2012 512 bit
+Description = cryptoPro2012Sign512A
+
+OID = 1 2 643 7 1 2 1 2 2
+Comment = CryptoPro ell.curve B for GOST R 34.10-2012 512 bit
+Description = cryptoPro2012Sign512B
+
+OID = 1 2 643 7 1 2 1 2 3
+Comment = CryptoPro ell.curve C for GOST R 34.10-2012 512 bit
+Description = cryptoPro2012Sign512C
+
+OID = 1 2 643 7 1 2 5 1 1
+Comment = TC26 params Z for GOST 28147-89
+Description = tc26CipherZ
 
 OID = 1 2 643 100 113 1
 Comment = CryptoPro GOST
@@ -2827,6 +2847,15 @@ OID = 1 2 840 113549 1 1 5
 Comment = PKCS #1
 Description = sha1WithRSAEncryption
 
+# There is some confusion over the identity of the following OID.  The OAEP
+# one is more recent but independent vendors have already used the RIPEMD
+# one, however it's likely that the SET usage will claim to be more
+# authoritative so we report it as that.
+OID = 1 2 840 113549 1 1 6
+Comment = PKCS #1. This OID may also be assigned as ripemd160WithRSAEncryption
+Description = rsaOAEPEncryptionSET
+# ripemd160WithRSAEncryption (1 2 840 113549 1 1 6)
+
 OID = 1 2 840 113549 1 1 7
 Comment = PKCS #1
 Description = rsaOAEP
@@ -2860,15 +2889,6 @@ Description = sha512WithRSAEncryption
 OID = 1 2 840 113549 1 1 14
 Comment = PKCS #1
 Description = sha224WithRSAEncryption
-
-# There is some confusion over the identity of the following OID.  The OAEP
-# one is more recent but independent vendors have already used the RIPEMD
-# one, however it's likely that the SET usage will claim to be more
-# authoritative so we report it as that.
-OID = 1 2 840 113549 1 1 6
-Comment = PKCS #1. This OID may also be assigned as ripemd160WithRSAEncryption
-Description = rsaOAEPEncryptionSET
-# ripemd160WithRSAEncryption (1 2 840 113549 1 1 6)
 
 # BSAFE/PKCS #2 (obsolete)
 
@@ -4392,16 +4412,6 @@ OID = 1 2 840 113549 3 10
 Comment = RSADSI encryptionAlgorithm. Formerly called CDMFCBCPad
 Description = desCDMF
 
-# Identrus
-
-OID = 1 2 840 114021 1 6 1
-Comment = Identrus
-Description = Identrus unknown policyIdentifier
-
-OID = 1 2 840 114021 4 1
-Comment = Identrus
-Description = identrusOCSP
-
 # Microsoft (both 1 2 840 and 1 3 6 1 4 1 arcs)
 
 OID = 1 2 840 113556 1 2 241
@@ -4897,6 +4907,38 @@ OID = 1 2 840 113635 100 15 3
 Comment = Apple custom certificate extension
 Description = appleCustomCertificateExtension3
 
+# Identrus
+
+OID = 1 2 840 114021 1 6 1
+Comment = Identrus
+Description = Identrus unknown policyIdentifier
+
+OID = 1 2 840 114021 4 1
+Comment = Identrus
+Description = identrusOCSP
+
+# Ascom Systech
+
+OID = 1 3 6 1 4 1 188 7 1 1
+Comment = Ascom Systech
+Description = ascom
+
+OID = 1 3 6 1 4 1 188 7 1 1 1
+Comment = Ascom Systech
+Description = ideaECB
+
+OID = 1 3 6 1 4 1 188 7 1 1 2
+Comment = Ascom Systech
+Description = ideaCBC
+
+OID = 1 3 6 1 4 1 188 7 1 1 3
+Comment = Ascom Systech
+Description = ideaCFB
+
+OID = 1 3 6 1 4 1 188 7 1 1 4
+Comment = Ascom Systech
+Description = ideaOFB
+
 # More Microsoft under the IETF arc
 
 OID = 1 3 6 1 4 1 311 2 1 4
@@ -5019,6 +5061,10 @@ OID = 1 3 6 1 4 1 311 10 3 4
 Comment = Microsoft extended key usage
 Description = encryptedFileSystem
 
+OID = 1 3 6 1 4 1 311 10 3 4 1
+Comment = Microsoft extended key usage
+Description = efsRecovery
+
 OID = 1 3 6 1 4 1 311 10 3 5
 Comment = Microsoft extended key usage
 Description = whqlCrypto
@@ -5066,10 +5112,6 @@ Description = smartDisplay
 OID = 1 3 6 1 4 1 311 10 3 16
 Comment = Microsoft extended key usage
 Description = cspSignature
-
-OID = 1 3 6 1 4 1 311 10 3 4 1
-Comment = Microsoft extended key usage
-Description = efsRecovery
 
 OID = 1 3 6 1 4 1 311 10 4 1
 Comment = Microsoft attribute
@@ -5367,10 +5409,6 @@ OID = 1 3 6 1 4 1 311 60 1 1
 Comment = Microsoft policy attribute
 Description = rootProgramFlags
 
-OID = 1 3 6 1 4 1 311 61 1 1
-Comment = Microsoft extended key usage
-Description = kernelModeCodeSigning
-
 OID = 1 3 6 1 4 1 311 60 2 1 1
 Comment = Microsoft (???)
 Description = jurisdictionOfIncorporationL
@@ -5382,6 +5420,10 @@ Description = jurisdictionOfIncorporationSP
 OID = 1 3 6 1 4 1 311 60 2 1 3
 Comment = Microsoft (???)
 Description = jurisdictionOfIncorporationC
+
+OID = 1 3 6 1 4 1 311 61 1 1
+Comment = Microsoft extended key usage
+Description = kernelModeCodeSigning
 
 OID = 1 3 6 1 4 1 311 76 509 1 1
 Comment = Microsoft PKI services
@@ -5415,27 +5457,9 @@ OID = 1 3 6 1 4 1 311 88 3 1
 Comment = Microsoft attribute
 Description = capiComEncryptedContent
 
-# Ascom Systech
-
-OID = 1 3 6 1 4 1 188 7 1 1
-Comment = Ascom Systech
-Description = ascom
-
-OID = 1 3 6 1 4 1 188 7 1 1 1
-Comment = Ascom Systech
-Description = ideaECB
-
-OID = 1 3 6 1 4 1 188 7 1 1 2
-Comment = Ascom Systech
-Description = ideaCBC
-
-OID = 1 3 6 1 4 1 188 7 1 1 3
-Comment = Ascom Systech
-Description = ideaCFB
-
-OID = 1 3 6 1 4 1 188 7 1 1 4
-Comment = Ascom Systech
-Description = ideaOFB
+OID = 1 3 6 1 4 1 782 1 2 1 8 1
+Comment = Network Solutions Certificate Authority
+Description = Network Solutions EV policy
 
 # Eurocontrol
 
@@ -5574,6 +5598,46 @@ OID = 1 3 6 1 4 1 3029 88 89 90 90 89
 Comment = cryptlib certificate policy
 Description = xYZZY policyIdentifier
 
+# PGP Inc.
+
+OID = 1 3 6 1 4 1 3401 8 1 1
+Comment = PGP key information
+Description = pgpExtension
+
+# EDI messaging for TMN Interactive Agents
+
+OID = 1 3 6 1 4 1 3576 7
+Comment = TMN EDI for Interactive Agents
+Description = eciaAscX12Edi
+
+OID = 1 3 6 1 4 1 3576 7 1
+Comment = TMN EDI for Interactive Agents
+Description = plainEDImessage
+
+OID = 1 3 6 1 4 1 3576 7 2
+Comment = TMN EDI for Interactive Agents
+Description = signedEDImessage
+
+OID = 1 3 6 1 4 1 3576 7 5
+Comment = TMN EDI for Interactive Agents
+Description = integrityEDImessage
+
+OID = 1 3 6 1 4 1 3576 7 65
+Comment = TMN EDI for Interactive Agents
+Description = iaReceiptMessage
+
+OID = 1 3 6 1 4 1 3576 7 97
+Comment = TMN EDI for Interactive Agents
+Description = iaStatusMessage
+
+OID = 1 3 6 1 4 1 3576 8
+Comment = TMN EDI for Interactive Agents
+Description = eciaEdifact
+
+OID = 1 3 6 1 4 1 3576 9
+Comment = TMN EDI for Interactive Agents
+Description = eciaNonEdi
+
 # AMD Secure Encrypted Virtualization (SEV) Versioned Chip Endorsement Key
 # (VCEK) and Versioned Loaded Endorsement Key (VLEK) OIDs, documented at
 # https://www.amd.com/system/files/TechDocs/57230.pdf
@@ -5626,46 +5690,6 @@ OID = 1 3 6 1 4 1 3704 1 5
 Comment = AMD SEV Versioned Loaded Endorsement Key
 Description = csp
 
-# PGP Inc.
-
-OID = 1 3 6 1 4 1 3401 8 1 1
-Comment = PGP key information
-Description = pgpExtension
-
-# EDI messaging for TMN Interactive Agents
-
-OID = 1 3 6 1 4 1 3576 7
-Comment = TMN EDI for Interactive Agents
-Description = eciaAscX12Edi
-
-OID = 1 3 6 1 4 1 3576 7 1
-Comment = TMN EDI for Interactive Agents
-Description = plainEDImessage
-
-OID = 1 3 6 1 4 1 3576 7 2
-Comment = TMN EDI for Interactive Agents
-Description = signedEDImessage
-
-OID = 1 3 6 1 4 1 3576 7 5
-Comment = TMN EDI for Interactive Agents
-Description = integrityEDImessage
-
-OID = 1 3 6 1 4 1 3576 7 65
-Comment = TMN EDI for Interactive Agents
-Description = iaReceiptMessage
-
-OID = 1 3 6 1 4 1 3576 7 97
-Comment = TMN EDI for Interactive Agents
-Description = iaStatusMessage
-
-OID = 1 3 6 1 4 1 3576 8
-Comment = TMN EDI for Interactive Agents
-Description = eciaEdifact
-
-OID = 1 3 6 1 4 1 3576 9
-Comment = TMN EDI for Interactive Agents
-Description = eciaNonEdi
-
 # Globalsign
 
 OID = 1 3 6 1 4 1 4146
@@ -5675,6 +5699,10 @@ Description = Globalsign
 OID = 1 3 6 1 4 1 4146 1
 Comment = Globalsign
 Description = globalsignPolicy
+
+OID = 1 3 6 1 4 1 4146 1 1
+Comment = GlobalSign
+Description = GlobalSign EV policy
 
 # Present in the EV policy OID collection at the end of this list
 #OID = 1 3 6 1 4 1 4146 1 1
@@ -5724,6 +5752,10 @@ Description = globalsignTPMRootPolicy
 OID = 1 3 6 1 4 1 4146 1 95
 Comment = Globalsign policy
 Description = globalsignOCSPPolicy
+
+OID = 1 3 6 1 4 1 4788 2 202 1
+Comment = D-TRUST Root Class 3 CA 2 EV 2009
+Description = D-TRUST EV policy
 
 # EdelWeb, http://timestamping.edelweb.fr
 
@@ -5779,11 +5811,19 @@ OID = 1 3 6 1 4 1 5770 0 4
 Comment = MEDePass
 Description = physicianIdentifiers
 
+OID = 1 3 6 1 4 1 6334 1 100 1
+Comment = Cybertrust Global Root (now Verizon Business)
+Description = Cybertrust EV policy
+
 # Comodo (formerly WoTrust) CA
 
 OID = 1 3 6 1 4 1 6449 1 2 1 3 1
 Comment = Comodo CA
 Description = comodoPolicy
+
+OID = 1 3 6 1 4 1 6449 1 2 1 5 1
+Comment = COMODO Certification Authority
+Description = Comodo EV policy
 
 OID = 1 3 6 1 4 1 6449 1 2 2 15
 Comment = WoTrust (Comodo) CA
@@ -5800,6 +5840,20 @@ OID = 1 3 6 1 4 1 6449 2 1 1
 Comment = Comodo CA
 Description = comodoTimestampingPolicy
 
+OID = 1 3 6 1 4 1 7879 13 24 1
+Comment = T-TeleSec GlobalRoot Class 3
+Description = T-TeleSec EV policy
+
+OID = 1 3 6 1 4 1 8024 0 2 100 1 2
+Comment = QuoVadis Root CA 2
+Description = QuoVadis EV policy
+
+# Chilean Government
+
+OID = 1 3 6 1 4 1 8231 1
+Comment = Chilean Government national unique roll number
+Description = rolUnicoNacional
+
 # TU Darmstadt ValidityModel
 # http://www.cdc.informatik.tu-darmstadt.de/TI/Forschung/FlexiPKI/validitymodel/index.html
 
@@ -5810,12 +5864,6 @@ Description = validityModelChain
 OID = 1 3 6 1 4 1 8301 3 5 2
 Comment = ValidityModel
 Description = validityModelShell
-
-# Chilean Government
-
-OID = 1 3 6 1 4 1 8231 1
-Comment = Chilean Government national unique roll number
-Description = rolUnicoNacional
 
 # Google.  These are CT OIDs but are never named anywhere in RFC 6962
 # or the followup RFC 9162, which just refers back to 6962.  The
@@ -5992,6 +6040,18 @@ OID = 1 3 6 1 4 1 11591 15 4
 Comment = GNU encryption algorithm
 Description = gnuEd448ph
 
+OID = 1 3 6 1 4 1 14370 1 6
+Comment = GeoTrust Primary Certification Authority (formerly Equifax)
+Description = GeoTrust EV policy
+
+OID = 1 3 6 1 4 1 14777 6 1 1
+Comment = Certificado de Servidor Seguro SSL EV
+Description = Izenpe EV policy
+
+OID = 1 3 6 1 4 1 14777 6 1 2
+Comment = Certificado de Sede Electronica EV
+Description = Izenpe EV policy
+
 # Northrop Grumman Mission Systems
 
 OID = 1 3 6 1 4 1 16334 509 1 1
@@ -6009,6 +6069,22 @@ Description = ngcClass2
 OID = 1 3 6 1 4 1 16334 509 2 3
 Comment = Northrop Grumman policy
 Description = ngcClass3
+
+OID = 1 3 6 1 4 1 17326 10 8 12 1 2
+Comment = Camerfirma CA Root
+Description = Camerfirma EV policy
+
+OID = 1 3 6 1 4 1 17326 10 14 2 1 2
+Comment = Camerfirma CA Root
+Description = Camerfirma EV policy
+
+OID = 1 3 6 1 4 1 22234 2 5 2 3 1
+Comment = CertPlus Class 2 Primary CA (formerly Keynectis)
+Description = CertPlus EV policy
+
+OID = 1 3 6 1 4 1 23223 1 1 1
+Comment = StartCom Certification Authority
+Description = StartCom EV policy
 
 # Safenet
 
@@ -6089,6 +6165,33 @@ Description = carillonExtKeyUsageLicenseSigning
 OID = 1 3 6 1 4 1 25054 3 8
 Comment = Carillon security
 Description = carillonCommercialSecret
+
+# This appears to be an error in Chromium's ev_root_ca_metadata.
+# OTOH this OID was also used by UTN-Userfirst, which is now
+# Comodo.
+#OID = 1 3 6 1 4 1 6449 1 2 1 5 1
+#Comment = AddTrust External CA Root
+#Description = AddTrust EV policy
+
+OID = 1 3 6 1 4 1 34697 2 1
+Comment = AffirmTrust Commercial
+Description = AffirmTrust EV policy
+
+OID = 1 3 6 1 4 1 34697 2 2
+Comment = AffirmTrust Networking
+Description = AffirmTrust EV policy
+
+OID = 1 3 6 1 4 1 34697 2 3
+Comment = AffirmTrust Premium
+Description = AffirmTrust EV policy
+
+OID = 1 3 6 1 4 1 34697 2 4
+Comment = AffirmTrust Premium ECC
+Description = AffirmTrust EV policy
+
+OID = 1 3 6 1 4 1 40869 1 1 22 3
+Comment = TWCA Root Certification Authority
+Description = TWCA EV policy
 
 # RFC 8649
 
@@ -7211,23 +7314,23 @@ OID = 1 3 14 3 2 2
 Comment = Oddball OIW OID
 Description = md4WitRSA
 
-OID = 1 3 14 3 2 3
-Comment = Oddball OIW OID
-Description = md5WithRSA
-
-OID = 1 3 14 3 2 4
-Comment = Oddball OIW OID
-Description = md4WithRSAEncryption
-
 OID = 1 3 14 3 2 2 1
 Comment = X.509. Deprecated
 Description = sqmod-N
 Warning
 
+OID = 1 3 14 3 2 3
+Comment = Oddball OIW OID
+Description = md5WithRSA
+
 OID = 1 3 14 3 2 3 1
 Comment = X.509. Deprecated
 Description = sqmod-NwithRSA
 Warning
+
+OID = 1 3 14 3 2 4
+Comment = Oddball OIW OID
+Description = md4WithRSAEncryption
 
 OID = 1 3 14 3 2 6
 Description = desECB
@@ -7519,26 +7622,6 @@ OID = 1 3 36 3 1 1 2 1 1
 Comment = Teletrust encryption algorithm
 Description = desCBC_ISOpad
 
-OID = 1 3 36 3 1 3
-Comment = Teletrust encryption algorithm
-Description = des_3
-
-OID = 1 3 36 3 1 3 1 1
-Comment = Teletrust encryption algorithm. EDE triple DES
-Description = des_3ECB_pad
-
-OID = 1 3 36 3 1 3 1 1 1
-Comment = Teletrust encryption algorithm. EDE triple DES
-Description = des_3ECB_ISOpad
-
-OID = 1 3 36 3 1 3 2 1
-Comment = Teletrust encryption algorithm. EDE triple DES
-Description = des_3CBC_pad
-
-OID = 1 3 36 3 1 3 2 1 1
-Comment = Teletrust encryption algorithm. EDE triple DES
-Description = des_3CBC_ISOpad
-
 OID = 1 3 36 3 1 2
 Comment = Teletrust encryption algorithm
 Description = idea
@@ -7574,6 +7657,26 @@ Description = ideaOFB
 OID = 1 3 36 3 1 2 4
 Comment = Teletrust encryption algorithm
 Description = ideaCFB
+
+OID = 1 3 36 3 1 3
+Comment = Teletrust encryption algorithm
+Description = des_3
+
+OID = 1 3 36 3 1 3 1 1
+Comment = Teletrust encryption algorithm. EDE triple DES
+Description = des_3ECB_pad
+
+OID = 1 3 36 3 1 3 1 1 1
+Comment = Teletrust encryption algorithm. EDE triple DES
+Description = des_3ECB_ISOpad
+
+OID = 1 3 36 3 1 3 2 1
+Comment = Teletrust encryption algorithm. EDE triple DES
+Description = des_3CBC_pad
+
+OID = 1 3 36 3 1 3 2 1 1
+Comment = Teletrust encryption algorithm. EDE triple DES
+Description = des_3CBC_ISOpad
 
 OID = 1 3 36 3 1 4
 Comment = Teletrust encryption algorithm
@@ -9669,6 +9772,10 @@ OID = 2 5 29 69
 Comment = X.509 extension
 Description = holderNameConstraints
 
+OID = 2 16 528 1 1001 1 1 1 12 6 1 1 1
+Comment = DigiNotar Root CA
+Description = DigiNotar EV policy
+
 # Norway Buypass CA.  Buypass doesn't provide names for any of these OIDs
 # so they've been synthesised from the description.
 
@@ -9683,6 +9790,11 @@ Description = privateKeySoftToken
 OID = 2 16 578 1 26 1 3 3
 Comment = Norway Buypass CA policy
 Description = sslEvident.  Also assigned as BuyPass EV policy
+
+# Also listed under the BuyPass CA entries, as a different OID.
+#OID = 2 16 578 1 26 1 3 3
+#Comment = BuyPass Class 3 EV
+#Description = BuyPass EV policy
 
 OID = 2 16 578 1 26 1 3 4
 Comment = Norway Buypass CA policy
@@ -9701,6 +9813,10 @@ Description = privateKeyHSM
 OID = 2 16 724 1 2 2 4 1
 Comment = Spanish Government PKI?
 Description = personalDataInfo
+
+OID = 2 16 756 1 89 1 2 1 1
+Comment = SwissSign Gold CA - G2
+Description = SwissSign EV policy
 
 # DMS
 
@@ -11165,6 +11281,12 @@ OID = 2 16 840 1 113730 4 1
 Comment = Netscape
 Description = serverGatedCrypto
 
+# SCEP
+
+OID = 2 16 840 1 113733 1
+Comment = Verisign extension
+Description = pki
+
 # Verisign
 
 # Country, zip, date of birth (age), and gender of cert owner (CZAG) in
@@ -11204,15 +11326,17 @@ OID = 2 16 840 1 113733 1 7 1 1 2
 Comment = Verisign policy (obsolete)
 Description = verisignCPSv1nsi
 
+OID = 2 16 840 1 113733 1 7 23 6
+Comment = VeriSign Class 3 Public Primary Certification Authority
+Description = VeriSign EV policy
+
+OID = 2 16 840 1 113733 1 7 48 1
+Comment = Thawte Premium Server CA
+Description = Thawte EV policy
+
 OID = 2 16 840 1 113733 1 8 1
 Comment = Verisign
 Description = verisignISSStrongCrypto
-
-# SCEP
-
-OID = 2 16 840 1 113733 1
-Comment = Verisign extension
-Description = pki
 
 OID = 2 16 840 1 113733 1 9
 Comment = Verisign PKI extension
@@ -11265,6 +11389,18 @@ OID = 2 16 840 1 113741 2
 Comment = Intel CDSA
 Description = intelCDSA
 
+OID = 2 16 840 1 114028 10 1 2
+Comment = Entrust Root Certification Authority
+Description = Entrust EV policy
+
+OID = 2 16 840 1 114171 500 9
+Comment = Wells Fargo WellsSecure Public Root Certificate Authority
+Description = Wells Fargo EV policy
+
+OID = 2 16 840 1 114404 1 1 2 4 1
+Comment = TrustWave CA, formerly SecureTrust, before that XRamp
+Description = TrustWave EV policy
+
 # DigiCert
 
 OID = 2 16 840 1 114412 1
@@ -11278,6 +11414,22 @@ Description = digiCertOVCert
 OID = 2 16 840 1 114412 1 2
 Comment = Digicert CA policy
 Description = digiCertDVCert
+
+OID = 2 16 840 1 114412 1 3 0 1
+Comment = Digicert CA policy
+Description = digiCertGlobalCAPolicy
+
+OID = 2 16 840 1 114412 1 3 0 2
+Comment = Digicert CA policy
+Description = digiCertHighAssuranceEVCAPolicy
+
+OID = 2 16 840 1 114412 1 3 0 3
+Comment = Digicert CA policy
+Description = digiCertGlobalRootCAPolicy
+
+OID = 2 16 840 1 114412 1 3 0 4
+Comment = Digicert CA policy
+Description = digiCertAssuredIDRootCAPolicy
 
 OID = 2 16 840 1 114412 1 5
 Comment = Digicert CA policy
@@ -11303,25 +11455,13 @@ OID = 2 16 840 1 114412 1 31
 Comment = Digicert CA policy
 Description = digiCertGridCert
 
-OID = 2 16 840 1 114412 1 3 0 1
-Comment = Digicert CA policy
-Description = digiCertGlobalCAPolicy
-
-OID = 2 16 840 1 114412 1 3 0 2
-Comment = Digicert CA policy
-Description = digiCertHighAssuranceEVCAPolicy
-
-OID = 2 16 840 1 114412 1 3 0 3
-Comment = Digicert CA policy
-Description = digiCertGlobalRootCAPolicy
-
-OID = 2 16 840 1 114412 1 3 0 4
-Comment = Digicert CA policy
-Description = digiCertAssuredIDRootCAPolicy
-
 OID = 2 16 840 1 114412 2 1
 Comment = Digicert CA policy
 Description = digiCertEVCert
+
+OID = 2 16 840 1 114412 2 1
+Comment = DigiCert High Assurance EV Root CA
+Description = DigiCert EV policy
 
 OID = 2 16 840 1 114412 2 2
 Comment = Digicert CA policy
@@ -11458,6 +11598,14 @@ Description = digiCertGridHostCert
 OID = 2 16 840 1 114412 36 1
 Comment = Digicert CA policy
 Description = digiCertOCSPSigning
+
+OID = 2 16 840 1 114413 1 7 23 3
+Comment = GoDaddy Class 2 Certification Authority (formerly ValiCert)
+Description = GoDaddy EV policy
+
+OID = 2 16 840 1 114414 1 7 23 3
+Comment = Starfield Class 2 Certification Authority
+Description = Starfield EV policy
 
 # SET
 
@@ -11922,19 +12070,19 @@ OID = 2 23 133 10 1 1 1
 Comment = TCPA/TCG Object
 Description = tcgObject
 
-# PostSignum.
-
-OID = 2 23 134 1 4 2 1
+OID = 2 23 134 1 2 1 8 210
 Comment = PostSignum CA
-Description = postSignumRootQCA
+Description = postSignumCommercialServerPolicy
 
 OID = 2 23 134 1 2 2 3
 Comment = PostSignum CA
 Description = postSignumPublicCA
 
-OID = 2 23 134 1 2 1 8 210
+# PostSignum.
+
+OID = 2 23 134 1 4 2 1
 Comment = PostSignum CA
-Description = postSignumCommercialServerPolicy
+Description = postSignumRootQCA
 
 # ICAO.  Technically this OID is called "SOD" but displaying that as a name
 # will just bugger up people's understanding of the data.  Newer versions of
@@ -11985,168 +12133,3 @@ OID = 2 54 1775 5
 Comment = SET.  Deprecated, use (2 23 42 7 0) instead
 Description = cardCertRequired
 Warning
-
-OID = 2 54 1775 6
-Comment = SET.  Deprecated, use (2 23 42 7 0) instead
-Description = tunneling
-Warning
-
-OID = 2 54 1775 7
-Comment = SET.  Deprecated, use (2 23 42 7 0) instead
-Description = setQualifier
-Warning
-
-OID = 2 54 1775 99
-Comment = SET.  Deprecated, use (2 23 42 7 0) instead
-Description = setData
-Warning
-
-# EV certificate policies.  There's no official record of what all the EV
-# policy OIDs are, it seems to be defined as "whatever the browsers will
-# accept as EV".  This is taken from
-# https://en.wikipedia.org/wiki/Extended_Validation_Certificate, there's also
-# a list in Chromium, the ev_root_ca_metadata list, but this contains
-# errors (e.g. the value "1.3.6.1.4.1.6449.1.2.1.5.1" [sic] is recorded as
-# being for both AddTrust and Comodo).
-#
-# The OIDs are collected here in owner-name alphabetical order rather than
-# scattering them throughout this list in OID order to make it easier to
-# track what's already present.
-
-OID = 1 2 40 0 17 1 22
-Comment = A-Trust CA Root
-Description = A-Trust EV policy
-
-# This appears to be an error in Chromium's ev_root_ca_metadata.
-# OTOH this OID was also used by UTN-Userfirst, which is now
-# Comodo.
-#OID = 1 3 6 1 4 1 6449 1 2 1 5 1
-#Comment = AddTrust External CA Root
-#Description = AddTrust EV policy
-
-OID = 1 3 6 1 4 1 34697 2 1
-Comment = AffirmTrust Commercial
-Description = AffirmTrust EV policy
-
-OID = 1 3 6 1 4 1 34697 2 2
-Comment = AffirmTrust Networking
-Description = AffirmTrust EV policy
-
-OID = 1 3 6 1 4 1 34697 2 3
-Comment = AffirmTrust Premium
-Description = AffirmTrust EV policy
-
-OID = 1 3 6 1 4 1 34697 2 4
-Comment = AffirmTrust Premium ECC
-Description = AffirmTrust EV policy
-
-# Also listed under the BuyPass CA entries, as a different OID.
-#OID = 2 16 578 1 26 1 3 3
-#Comment = BuyPass Class 3 EV
-#Description = BuyPass EV policy
-
-OID = 1 3 6 1 4 1 17326 10 14 2 1 2
-Comment = Camerfirma CA Root
-Description = Camerfirma EV policy
-
-OID = 1 3 6 1 4 1 17326 10 8 12 1 2
-Comment = Camerfirma CA Root
-Description = Camerfirma EV policy
-
-OID = 1 3 6 1 4 1 22234 2 5 2 3 1
-Comment = CertPlus Class 2 Primary CA (formerly Keynectis)
-Description = CertPlus EV policy
-
-OID = 1 3 6 1 4 1 6449 1 2 1 5 1
-Comment = COMODO Certification Authority
-Description = Comodo EV policy
-
-OID = 1 3 6 1 4 1 6334 1 100 1
-Comment = Cybertrust Global Root (now Verizon Business)
-Description = Cybertrust EV policy
-
-OID = 1 3 6 1 4 1 4788 2 202 1
-Comment = D-TRUST Root Class 3 CA 2 EV 2009
-Description = D-TRUST EV policy
-
-OID = 2 16 840 1 114412 2 1
-Comment = DigiCert High Assurance EV Root CA
-Description = DigiCert EV policy
-
-OID = 2 16 528 1 1001 1 1 1 12 6 1 1 1
-Comment = DigiNotar Root CA
-Description = DigiNotar EV policy
-
-OID = 2 16 840 1 114028 10 1 2
-Comment = Entrust Root Certification Authority
-Description = Entrust EV policy
-
-OID = 1 3 6 1 4 1 14370 1 6
-Comment = GeoTrust Primary Certification Authority (formerly Equifax)
-Description = GeoTrust EV policy
-
-OID = 1 3 6 1 4 1 4146 1 1
-Comment = GlobalSign
-Description = GlobalSign EV policy
-
-OID = 2 16 840 1 114413 1 7 23 3
-Comment = GoDaddy Class 2 Certification Authority (formerly ValiCert)
-Description = GoDaddy EV policy
-
-OID = 1 3 6 1 4 1 14777 6 1 1
-Comment = Certificado de Servidor Seguro SSL EV
-Description = Izenpe EV policy
-
-OID = 1 3 6 1 4 1 14777 6 1 2
-Comment = Certificado de Sede Electronica EV
-Description = Izenpe EV policy
-
-OID = 1 3 6 1 4 1 782 1 2 1 8 1
-Comment = Network Solutions Certificate Authority
-Description = Network Solutions EV policy
-
-OID = 1 3 6 1 4 1 8024 0 2 100 1 2
-Comment = QuoVadis Root CA 2
-Description = QuoVadis EV policy
-
-OID = 1 2 392 200091 100 721 1
-Comment = Security Communication RootCA1
-Description = Security Communication (SECOM) EV policy
-
-OID = 2 16 840 1 114414 1 7 23 3
-Comment = Starfield Class 2 Certification Authority
-Description = Starfield EV policy
-
-OID = 1 3 6 1 4 1 23223 1 1 1
-Comment = StartCom Certification Authority
-Description = StartCom EV policy
-
-OID = 2 16 756 1 89 1 2 1 1
-Comment = SwissSign Gold CA - G2
-Description = SwissSign EV policy
-
-OID = 1 3 6 1 4 1 7879 13 24 1
-Comment = T-TeleSec GlobalRoot Class 3
-Description = T-TeleSec EV policy
-
-OID = 2 16 840 1 113733 1 7 48 1
-Comment = Thawte Premium Server CA
-Description = Thawte EV policy
-
-OID = 2 16 840 1 114404 1 1 2 4 1
-Comment = TrustWave CA, formerly SecureTrust, before that XRamp
-Description = TrustWave EV policy
-
-OID = 1 3 6 1 4 1 40869 1 1 22 3
-Comment = TWCA Root Certification Authority
-Description = TWCA EV policy
-
-OID = 2 16 840 1 113733 1 7 23 6
-Comment = VeriSign Class 3 Public Primary Certification Authority
-Description = VeriSign EV policy
-
-OID = 2 16 840 1 114171 500 9
-Comment = Wells Fargo WellsSecure Public Root Certificate Authority
-Description = Wells Fargo EV policy
-
-# End of Fahnenstange


### PR DESCRIPTION
For ease of maintenance, I sorted the OIDs by numeric value.

I used [a NodeJS script I did commit in a different branch](https://github.com/lapo-luchini/dumpasn1/blob/sortScript/sort.js) not to include in this commit.

I also add a `.gitattirbutes` file in order to enforce current line endings to avoid changing them during sort.